### PR TITLE
hostilefork.json => now runs relative to cwd

### DIFF
--- a/rebol/hostilefork.json
+++ b/rebol/hostilefork.json
@@ -41,7 +41,7 @@
         { "long": "strict", "desc": "Only allow `.ws`, `.wsa`, and `.wsw` formats" }
       ],
       "option_parse": "manual",
-      "notes": "File path is relative to whitespace.reb, not PWD"
+      "notes": "Implementation is using a pure usermode PARSE dialect prototype, slowness is to be expected."
     },
     {
       "type": "interpreter",


### PR DESCRIPTION
As a new rule for Ren-C as a whole, scripts don't change the working
directory when invoked from the command line.  Instead, the feature
of finding resources relative to the script location is done by using
TAG! values as the argument to DO, LOAD, IMPORT:

https://github.com/metaeducation/rebol-issues/issues/2374#issuecomment-912266377

So long as the note needs changing, this goes ahead and mentions
that the whitespace interpreter is being used as a testbed for the
UPARSE parser that is written entirely in interpreted usermode
code, and is thus glacially slow compared to native code.  The
native code rewrite is being held off until a working stream
parsing design has been achieved.